### PR TITLE
Skip whitespace-only segments before @mentions in webhook parsing

### DIFF
--- a/core/webhook.py
+++ b/core/webhook.py
@@ -65,10 +65,12 @@ class VoceChatWebhook:
             for match in re.finditer(mention_pattern, content):
                 # 添加@之前的文本
                 if match.start() > current_pos:
-                    message.append({
-                        "type": "text",
-                        "data": {"text": content[current_pos:match.start()]}
-                    })
+                    pre_text = content[current_pos:match.start()]
+                    if pre_text.strip():
+                        message.append({
+                            "type": "text",
+                            "data": {"text": pre_text}
+                        })
                 
                 # 添加@消息段
                 message.append({


### PR DESCRIPTION
### Motivation
- VoceChat messages sometimes have a leading space before an `@` mention which previously produced a separate whitespace-only text segment. 
- That whitespace-only segment caused downstream message consumers to see extraneous empty text fragments like `{'type': 'text', 'data': {'text': ' '}}` before mention tokens. 

### Description
- In `core/webhook.py` mention parsing, compute `pre_text` for text before each match and only append it if `pre_text.strip()` is non-empty. 
- The change prevents emitting whitespace-only text segments before `mention` tokens while preserving other text and mention parsing behavior. 
- Minor file formatting fix: ensure newline at end of `core/webhook.py`.

### Testing
- No automated tests were run for this change.
- Commit was created and the modified file `core/webhook.py` was updated without runtime tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69608dfbf614832a978fc36e0d2364ee)